### PR TITLE
Build for core5 only

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/samples/ThisNetWorks.OrchardCore.OpenApi.Sample/bin/Debug/netcoreapp3.1/ThisNetWorks.OrchardCore.OpenApi.Sample.dll",
+            "program": "${workspaceFolder}/samples/ThisNetWorks.OrchardCore.OpenApi.Sample/bin/Debug/net5.0/ThisNetWorks.OrchardCore.OpenApi.Sample.dll",
             "args": [],
             "cwd": "${workspaceFolder}/samples/ThisNetWorks.OrchardCore.OpenApi.Sample",
             "stopAtEntry": false,

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,20 +4,20 @@
     <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Update="NJsonSchema" Version="10.3.10" />
     <PackageReference Update="NSwag.AspNetCore" Version="13.10.7" />
-    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.ContentFields" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.ContentManagement" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Contents.Core" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Flows" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Html" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Lists" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Infrastructure" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Module.Targets" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.0.0-rc2-15900" />
-    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.0.0-rc2-15900" />
+    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.ContentFields" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.ContentManagement" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Contents.Core" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Flows" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Html" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Lists" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Infrastructure" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Module.Targets" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.0.0-rc2-15913" />
+    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.0.0-rc2-15913" />
   </ItemGroup>
 </Project>  

--- a/samples/ThisNetWorks.OrchardCore.OpenApi.SampleTheme/Recipes/openapisample.recipe.json
+++ b/samples/ThisNetWorks.OrchardCore.OpenApi.SampleTheme/Recipes/openapisample.recipe.json
@@ -40,6 +40,6 @@
       "name": "themes",
       "admin": "TheAdmin",
       "site": "ThisNetWorks.OrchardCore.OpenApi.SampleTheme"
-    },
+    }
   ]
 }

--- a/src/ThisNetWorks.OrchardCore.OpenApi/Manifest.cs
+++ b/src/ThisNetWorks.OrchardCore.OpenApi/Manifest.cs
@@ -2,7 +2,7 @@ using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
     Id = "ThisNetWorks.OrchardCore.OpenApi",
-    Name = "Orchard Core OpenAPI Tools",
+    Name = "OpenAPI Tools",
     Author = "ThisNetWorks",
     Website = "https://github.com/ThisNetWorks",
     Version = "1.0.0",

--- a/src/ThisNetWorks.OrchardCore.OpenApi/ThisNetWorks.OrchardCore.OpenApi.csproj
+++ b/src/ThisNetWorks.OrchardCore.OpenApi/ThisNetWorks.OrchardCore.OpenApi.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <!-- <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks> -->
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
+++ b/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>net5.0</TargetFramework> -->
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
+++ b/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <!-- <TargetFramework>net5.0</TargetFramework> -->
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Due to an issue with Orchard Core module discovery when building packed multi targetted modules they are not discovered unless the entire project consumes both frameworks.

This is a build for core 5. 

Consumers of core 3 will now need to use older versions.

