### PR TITLE
.NET 6.0 compatibility + OC 1.2.0-preview-16640

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,22 +2,22 @@
 
   <ItemGroup>
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="NJsonSchema" Version="10.5.2" />
-    <PackageReference Update="NSwag.AspNetCore" Version="13.13.2" />
-    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16631" />
-    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16631" />
+    <PackageReference Update="NJsonSchema" Version="10.6.6" />
+    <PackageReference Update="NSwag.AspNetCore" Version="13.15.5" />
+    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16640" />
+    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16640" />
   </ItemGroup>
 </Project>  

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,20 +4,20 @@
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="NJsonSchema" Version="10.5.2" />
     <PackageReference Update="NSwag.AspNetCore" Version="13.13.2" />
-    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16607" />
+    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16631" />
   </ItemGroup>
 </Project>  

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,22 +2,22 @@
 
   <ItemGroup>
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="NJsonSchema" Version="10.5.2" />
-    <PackageReference Update="NSwag.AspNetCore" Version="13.13.2" />
-    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16607" />
-    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16607" />
+    <PackageReference Update="NJsonSchema" Version="10.6.6" />
+    <PackageReference Update="NSwag.AspNetCore" Version="13.15.5" />
+    <PackageReference Update="OrchardCore.Application.Cms.Targets" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentFields" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentManagement.Abstractions" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Contents.Core" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ContentTypes.Abstractions" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.DisplayManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Flows" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Html" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Lists" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Infrastructure" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Logging.NLog" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Module.Targets" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.ResourceManagement" Version="1.2.0-preview-16631" />
+    <PackageReference Update="OrchardCore.Theme.Targets" Version="1.2.0-preview-16631" />
   </ItemGroup>
 </Project>  

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <PackageTags>openapi;swagger;orchardcore;</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>

--- a/src/ThisNetWorks.OrchardCore.OpenApi.Abstractions/ThisNetWorks.OrchardCore.OpenApi.Abstractions.csproj
+++ b/src/ThisNetWorks.OrchardCore.OpenApi.Abstractions/ThisNetWorks.OrchardCore.OpenApi.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>ThisNetWorks.OrchardCore.OpenApi</RootNamespace>
   </PropertyGroup>
   

--- a/src/ThisNetWorks.OrchardCore.OpenApi/ThisNetWorks.OrchardCore.OpenApi.csproj
+++ b/src/ThisNetWorks.OrchardCore.OpenApi/ThisNetWorks.OrchardCore.OpenApi.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
+++ b/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
+++ b/tests/ThisNetWorks.OrchardCore.OpenApi.Tests/ThisNetWorks.OrchardCore.OpenApi.Tests.csproj
@@ -8,9 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Update NSwag to support .NET 6.0
Also update OC to 1.2.0-preview-16631 (version 6.0.1 for extensions)
Had issues pulling down 1.2.0-preview-16625